### PR TITLE
Workaround a bug in MacOS sockets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tcp_typed"
-version = "0.1.3"
+version = "0.1.4"
 license = "MIT OR Apache-2.0"
 authors = ["Alec Mocatta <alec@mocatta.net>"]
 categories = ["development-tools","network-programming"]
@@ -14,7 +14,7 @@ This library aims to make it impossible to misuse in non-unsafe code.
 """
 repository = "https://github.com/alecmocatta/tcp_typed"
 homepage = "https://github.com/alecmocatta/tcp_typed"
-documentation = "https://docs.rs/tcp_typed/0.1.2"
+documentation = "https://docs.rs/tcp_typed/0.1.4"
 readme = "README.md"
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ maintenance = { status = "actively-developed" }
 itertools = "0.8"
 log = "0.4"
 palaver = "0.2"
+socketstat = "0.1"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.15"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![MIT / Apache 2.0 licensed](https://img.shields.io/crates/l/tcp_typed.svg?maxAge=2592000)](#License)
 [![Build Status](https://dev.azure.com/alecmocatta/tcp_typed/_apis/build/status/tests?branchName=master)](https://dev.azure.com/alecmocatta/tcp_typed/_build/latest?branchName=master)
 
-[Docs](https://docs.rs/tcp_typed/0.1.2)
+[Docs](https://docs.rs/tcp_typed/0.1.4)
 
 A wrapper around platform TCP socket APIs that leverages the type system to ensure correct usage.
 
@@ -14,7 +14,7 @@ This library aims to make it impossible to misuse in non-unsafe code.
 
 If you ever see a connection reset / ECONNRESET, EPIPE, data being lost on close, or panic, then it is a bug in this library! Please file an issue with as much info as possible.
 
-It's designed to be used in conjunction with an implementer of the [`Notifier`](https://docs.rs/tcp_typed/0.1.2/tcp_typed/trait.Notifier.html) trait – for example [`notifier`](https://github.com/alecmocatta/notifier). As long as the [`Notifier`](https://docs.rs/tcp_typed/0.1.2/tcp_typed/trait.Notifier.html) contract is fulfilled, then this library will collect all relevent events (connected, data in, data available to be written, remote closed, bytes acked, connection errors) upon each edge-triggered notification.
+It's designed to be used in conjunction with an implementer of the [`Notifier`](https://docs.rs/tcp_typed/0.1.4/tcp_typed/trait.Notifier.html) trait – for example [`notifier`](https://github.com/alecmocatta/notifier). As long as the [`Notifier`](https://docs.rs/tcp_typed/0.1.4/tcp_typed/trait.Notifier.html) contract is fulfilled, then this library will collect all relevent events (connected, data in, data available to be written, remote closed, bytes acked, connection errors) upon each edge-triggered notification.
 
 ## Note
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
     endpoint: alecmocatta
     default:
       rust_toolchain: nightly
-      rust_lint_toolchain: nightly-2019-07-19
+      rust_lint_toolchain: nightly-2019-08-22
       rust_flags: ''
       rust_features: ''
       rust_target_check: ''

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -23,37 +23,37 @@ impl Connection {
 		Connecter::new(local, remote, executor).into()
 	}
 	pub fn poll(&mut self, executor: &impl Notifier) {
-		*self = match mem::replace(self, Connection::Killed) {
-			Connection::Connecter(connecter) => connecter.poll(executor).into(),
-			Connection::Connectee(connectee) => connectee.poll(executor).into(),
-			Connection::ConnecterLocalClosed(connected_local_closed) => {
+		*self = match mem::replace(self, Self::Killed) {
+			Self::Connecter(connecter) => connecter.poll(executor).into(),
+			Self::Connectee(connectee) => connectee.poll(executor).into(),
+			Self::ConnecterLocalClosed(connected_local_closed) => {
 				connected_local_closed.poll(executor).into()
 			}
-			Connection::ConnecteeLocalClosed(connectee_local_closed) => {
+			Self::ConnecteeLocalClosed(connectee_local_closed) => {
 				connectee_local_closed.poll(executor).into()
 			}
-			Connection::Connected(connected) => connected.poll(executor).into(),
-			Connection::RemoteClosed(remote_closed) => remote_closed.poll(executor).into(),
-			Connection::LocalClosed(local_closed) => local_closed.poll(executor).into(),
-			Connection::Closing(closing) => closing.poll(executor).into(),
-			Connection::Closed => Connection::Closed,
-			Connection::Killed => Connection::Killed,
+			Self::Connected(connected) => connected.poll(executor).into(),
+			Self::RemoteClosed(remote_closed) => remote_closed.poll(executor).into(),
+			Self::LocalClosed(local_closed) => local_closed.poll(executor).into(),
+			Self::Closing(closing) => closing.poll(executor).into(),
+			Self::Closed => Self::Closed,
+			Self::Killed => Self::Killed,
 		};
 	}
 	#[inline(always)]
 	pub fn connecting(&self) -> bool {
 		match self {
-			Connection::Connecter(_)
-			| Connection::Connectee(_)
-			| Connection::ConnecterLocalClosed(_)
-			| Connection::ConnecteeLocalClosed(_) => true,
+			Self::Connecter(_)
+			| Self::Connectee(_)
+			| Self::ConnecterLocalClosed(_)
+			| Self::ConnecteeLocalClosed(_) => true,
 			_ => false,
 		}
 	}
 	#[inline(always)]
 	pub fn recvable(&self) -> bool {
 		match self {
-			Connection::Connected(_) | Connection::LocalClosed(_) => true,
+			Self::Connected(_) | Self::LocalClosed(_) => true,
 			_ => false,
 		}
 	}
@@ -61,8 +61,8 @@ impl Connection {
 	pub fn recv_avail(&self) -> Option<usize> {
 		if self.recvable() {
 			Some(match self {
-				Connection::Connected(ref connected) => connected.recv_avail(),
-				Connection::LocalClosed(ref local_closed) => local_closed.recv_avail(),
+				Self::Connected(ref connected) => connected.recv_avail(),
+				Self::LocalClosed(ref local_closed) => local_closed.recv_avail(),
 				_ => unreachable!(),
 			})
 		} else {
@@ -75,8 +75,8 @@ impl Connection {
 		self.recv_avail().and_then(move |avail| {
 			if avail > 0 {
 				Some(move || match self {
-					Connection::Connected(ref mut connected) => connected.recv(executor).unwrap()(),
-					Connection::LocalClosed(ref mut local_closed) => {
+					Self::Connected(ref mut connected) => connected.recv(executor).unwrap()(),
+					Self::LocalClosed(ref mut local_closed) => {
 						local_closed.recv(executor).unwrap()()
 					}
 					_ => unreachable!(),
@@ -89,7 +89,7 @@ impl Connection {
 	#[inline(always)]
 	pub fn sendable(&self) -> bool {
 		match self {
-			Connection::Connected(_) | Connection::RemoteClosed(_) => true,
+			Self::Connected(_) | Self::RemoteClosed(_) => true,
 			_ => false,
 		}
 	}
@@ -98,8 +98,8 @@ impl Connection {
 		if self.sendable() {
 			Some({
 				match self {
-					Connection::Connected(ref connected) => connected.send_avail(),
-					Connection::RemoteClosed(ref remote_closed) => remote_closed.send_avail(),
+					Self::Connected(ref connected) => connected.send_avail(),
+					Self::RemoteClosed(ref remote_closed) => remote_closed.send_avail(),
 					_ => unreachable!(),
 				}
 			})
@@ -113,10 +113,8 @@ impl Connection {
 		self.send_avail().and_then(move |avail| {
 			if avail > 0 {
 				Some(move |x| match self {
-					Connection::Connected(ref mut connected) => {
-						connected.send(executor).unwrap()(x)
-					}
-					Connection::RemoteClosed(ref mut remote_closed) => {
+					Self::Connected(ref mut connected) => connected.send(executor).unwrap()(x),
+					Self::RemoteClosed(ref mut remote_closed) => {
 						remote_closed.send(executor).unwrap()(x)
 					}
 					_ => unreachable!(),
@@ -129,49 +127,49 @@ impl Connection {
 	#[inline(always)]
 	pub fn closed(&self) -> bool {
 		match self {
-			Connection::Closed => true,
+			Self::Closed => true,
 			_ => false,
 		}
 	}
 	#[inline(always)]
 	pub fn valid(&self) -> bool {
 		match self {
-			Connection::Connecter(_)
-			| Connection::Connectee(_)
-			| Connection::ConnecterLocalClosed(_)
-			| Connection::ConnecteeLocalClosed(_)
-			| Connection::Connected(_)
-			| Connection::RemoteClosed(_)
-			| Connection::LocalClosed(_)
-			| Connection::Closing(_)
-			| Connection::Closed => true,
-			Connection::Killed => false,
+			Self::Connecter(_)
+			| Self::Connectee(_)
+			| Self::ConnecterLocalClosed(_)
+			| Self::ConnecteeLocalClosed(_)
+			| Self::Connected(_)
+			| Self::RemoteClosed(_)
+			| Self::LocalClosed(_)
+			| Self::Closing(_)
+			| Self::Closed => true,
+			Self::Killed => false,
 		}
 	}
 	#[inline(always)]
 	pub fn closable(&self) -> bool {
 		match self {
-			Connection::Connecter(_)
-			| Connection::Connectee(_)
-			| Connection::Connected(_)
-			| Connection::RemoteClosed(_) => true,
-			Connection::ConnecterLocalClosed(_)
-			| Connection::ConnecteeLocalClosed(_)
-			| Connection::LocalClosed(_)
-			| Connection::Closing(_)
-			| Connection::Closed
-			| Connection::Killed => false,
+			Self::Connecter(_)
+			| Self::Connectee(_)
+			| Self::Connected(_)
+			| Self::RemoteClosed(_) => true,
+			Self::ConnecterLocalClosed(_)
+			| Self::ConnecteeLocalClosed(_)
+			| Self::LocalClosed(_)
+			| Self::Closing(_)
+			| Self::Closed
+			| Self::Killed => false,
 		}
 	}
 	#[must_use]
 	pub fn close<'a>(&'a mut self, executor: &'a impl Notifier) -> Option<impl FnOnce() + 'a> {
 		if self.closable() {
 			Some(move || {
-				*self = match mem::replace(self, Connection::Killed) {
-					Connection::Connecter(connecter) => connecter.close(executor).into(),
-					Connection::Connectee(connectee) => connectee.close(executor).into(),
-					Connection::Connected(connected) => connected.close(executor).into(),
-					Connection::RemoteClosed(remote_closed) => remote_closed.close(executor).into(),
+				*self = match mem::replace(self, Self::Killed) {
+					Self::Connecter(connecter) => connecter.close(executor).into(),
+					Self::Connectee(connectee) => connectee.close(executor).into(),
+					Self::Connected(connected) => connected.close(executor).into(),
+					Self::RemoteClosed(remote_closed) => remote_closed.close(executor).into(),
 					_ => unreachable!(),
 				};
 			})
@@ -182,34 +180,34 @@ impl Connection {
 	#[inline(always)]
 	pub fn killable(&self) -> bool {
 		match self {
-			Connection::Connecter(_)
-			| Connection::Connectee(_)
-			| Connection::ConnecterLocalClosed(_)
-			| Connection::ConnecteeLocalClosed(_)
-			| Connection::Connected(_)
-			| Connection::RemoteClosed(_)
-			| Connection::LocalClosed(_)
-			| Connection::Closing(_) => true,
-			Connection::Closed | Connection::Killed => false,
+			Self::Connecter(_)
+			| Self::Connectee(_)
+			| Self::ConnecterLocalClosed(_)
+			| Self::ConnecteeLocalClosed(_)
+			| Self::Connected(_)
+			| Self::RemoteClosed(_)
+			| Self::LocalClosed(_)
+			| Self::Closing(_) => true,
+			Self::Closed | Self::Killed => false,
 		}
 	}
 	#[must_use]
 	pub fn kill<'a>(&'a mut self, executor: &'a impl Notifier) -> Option<impl FnOnce() + 'a> {
 		if self.killable() {
 			Some(move || {
-				match mem::replace(self, Connection::Killed) {
-					Connection::Connecter(connecter) => connecter.kill(executor),
-					Connection::Connectee(connectee) => connectee.kill(executor),
-					Connection::Connected(connected) => connected.kill(executor),
-					Connection::RemoteClosed(remote_closed) => remote_closed.kill(executor),
-					Connection::LocalClosed(local_closed) => local_closed.kill(executor),
-					Connection::ConnecterLocalClosed(connecter_local_closed) => {
+				match mem::replace(self, Self::Killed) {
+					Self::Connecter(connecter) => connecter.kill(executor),
+					Self::Connectee(connectee) => connectee.kill(executor),
+					Self::Connected(connected) => connected.kill(executor),
+					Self::RemoteClosed(remote_closed) => remote_closed.kill(executor),
+					Self::LocalClosed(local_closed) => local_closed.kill(executor),
+					Self::ConnecterLocalClosed(connecter_local_closed) => {
 						connecter_local_closed.kill(executor)
 					}
-					Connection::ConnecteeLocalClosed(connectee_local_closed) => {
+					Self::ConnecteeLocalClosed(connectee_local_closed) => {
 						connectee_local_closed.kill(executor)
 					}
-					Connection::Closing(closing) => closing.kill(executor),
+					Self::Closing(closing) => closing.kill(executor),
 					_ => unreachable!(),
 				};
 			})
@@ -221,41 +219,41 @@ impl Connection {
 impl From<Connecter> for Connection {
 	#[inline(always)]
 	fn from(connecter: Connecter) -> Self {
-		Connection::Connecter(connecter)
+		Self::Connecter(connecter)
 	}
 }
 impl From<ConnecterPoll> for Connection {
 	#[inline(always)]
 	fn from(connecter_poll: ConnecterPoll) -> Self {
 		match connecter_poll {
-			ConnecterPoll::Connecter(connecter) => Connection::Connecter(connecter),
-			ConnecterPoll::Connected(connected) => Connection::Connected(connected),
-			ConnecterPoll::RemoteClosed(remote_closed) => Connection::RemoteClosed(remote_closed),
-			ConnecterPoll::Killed => Connection::Killed,
+			ConnecterPoll::Connecter(connecter) => Self::Connecter(connecter),
+			ConnecterPoll::Connected(connected) => Self::Connected(connected),
+			ConnecterPoll::RemoteClosed(remote_closed) => Self::RemoteClosed(remote_closed),
+			ConnecterPoll::Killed => Self::Killed,
 		}
 	}
 }
 impl From<Connectee> for Connection {
 	#[inline(always)]
 	fn from(connectee: Connectee) -> Self {
-		Connection::Connectee(connectee)
+		Self::Connectee(connectee)
 	}
 }
 impl From<ConnecteePoll> for Connection {
 	#[inline(always)]
 	fn from(connectee_poll: ConnecteePoll) -> Self {
 		match connectee_poll {
-			ConnecteePoll::Connectee(connectee) => Connection::Connectee(connectee),
-			ConnecteePoll::Connected(connected) => Connection::Connected(connected),
-			ConnecteePoll::RemoteClosed(remote_closed) => Connection::RemoteClosed(remote_closed),
-			ConnecteePoll::Killed => Connection::Killed,
+			ConnecteePoll::Connectee(connectee) => Self::Connectee(connectee),
+			ConnecteePoll::Connected(connected) => Self::Connected(connected),
+			ConnecteePoll::RemoteClosed(remote_closed) => Self::RemoteClosed(remote_closed),
+			ConnecteePoll::Killed => Self::Killed,
 		}
 	}
 }
 impl From<ConnecterLocalClosed> for Connection {
 	#[inline(always)]
 	fn from(connecter_local_closed: ConnecterLocalClosed) -> Self {
-		Connection::ConnecterLocalClosed(connecter_local_closed)
+		Self::ConnecterLocalClosed(connecter_local_closed)
 	}
 }
 impl From<ConnecterLocalClosedPoll> for Connection {
@@ -263,21 +261,19 @@ impl From<ConnecterLocalClosedPoll> for Connection {
 	fn from(connecter_local_closed_poll: ConnecterLocalClosedPoll) -> Self {
 		match connecter_local_closed_poll {
 			ConnecterLocalClosedPoll::ConnecterLocalClosed(connecter_local_closed) => {
-				Connection::ConnecterLocalClosed(connecter_local_closed)
+				Self::ConnecterLocalClosed(connecter_local_closed)
 			}
-			ConnecterLocalClosedPoll::LocalClosed(local_closed) => {
-				Connection::LocalClosed(local_closed)
-			}
-			ConnecterLocalClosedPoll::Closing(closing) => Connection::Closing(closing),
-			ConnecterLocalClosedPoll::Closed => Connection::Closed,
-			ConnecterLocalClosedPoll::Killed => Connection::Killed,
+			ConnecterLocalClosedPoll::LocalClosed(local_closed) => Self::LocalClosed(local_closed),
+			ConnecterLocalClosedPoll::Closing(closing) => Self::Closing(closing),
+			ConnecterLocalClosedPoll::Closed => Self::Closed,
+			ConnecterLocalClosedPoll::Killed => Self::Killed,
 		}
 	}
 }
 impl From<ConnecteeLocalClosed> for Connection {
 	#[inline(always)]
 	fn from(connectee_local_closed: ConnecteeLocalClosed) -> Self {
-		Connection::ConnecteeLocalClosed(connectee_local_closed)
+		Self::ConnecteeLocalClosed(connectee_local_closed)
 	}
 }
 impl From<ConnecteeLocalClosedPoll> for Connection {
@@ -285,80 +281,76 @@ impl From<ConnecteeLocalClosedPoll> for Connection {
 	fn from(connectee_local_closed_poll: ConnecteeLocalClosedPoll) -> Self {
 		match connectee_local_closed_poll {
 			ConnecteeLocalClosedPoll::ConnecteeLocalClosed(connectee_local_closed) => {
-				Connection::ConnecteeLocalClosed(connectee_local_closed)
+				Self::ConnecteeLocalClosed(connectee_local_closed)
 			}
-			ConnecteeLocalClosedPoll::LocalClosed(local_closed) => {
-				Connection::LocalClosed(local_closed)
-			}
-			ConnecteeLocalClosedPoll::Closing(closing) => Connection::Closing(closing),
-			ConnecteeLocalClosedPoll::Closed => Connection::Closed,
-			ConnecteeLocalClosedPoll::Killed => Connection::Killed,
+			ConnecteeLocalClosedPoll::LocalClosed(local_closed) => Self::LocalClosed(local_closed),
+			ConnecteeLocalClosedPoll::Closing(closing) => Self::Closing(closing),
+			ConnecteeLocalClosedPoll::Closed => Self::Closed,
+			ConnecteeLocalClosedPoll::Killed => Self::Killed,
 		}
 	}
 }
 impl From<Connected> for Connection {
 	#[inline(always)]
 	fn from(connected: Connected) -> Self {
-		Connection::Connected(connected)
+		Self::Connected(connected)
 	}
 }
 impl From<ConnectedPoll> for Connection {
 	#[inline(always)]
 	fn from(connected_poll: ConnectedPoll) -> Self {
 		match connected_poll {
-			ConnectedPoll::Connected(connected) => Connection::Connected(connected),
-			ConnectedPoll::RemoteClosed(remote_closed) => Connection::RemoteClosed(remote_closed),
-			ConnectedPoll::Killed => Connection::Killed,
+			ConnectedPoll::Connected(connected) => Self::Connected(connected),
+			ConnectedPoll::RemoteClosed(remote_closed) => Self::RemoteClosed(remote_closed),
+			ConnectedPoll::Killed => Self::Killed,
 		}
 	}
 }
 impl From<RemoteClosed> for Connection {
 	#[inline(always)]
 	fn from(remote_closed: RemoteClosed) -> Self {
-		Connection::RemoteClosed(remote_closed)
+		Self::RemoteClosed(remote_closed)
 	}
 }
 impl From<RemoteClosedPoll> for Connection {
 	#[inline(always)]
 	fn from(remote_closed_poll: RemoteClosedPoll) -> Self {
 		match remote_closed_poll {
-			RemoteClosedPoll::RemoteClosed(remote_closed) => {
-				Connection::RemoteClosed(remote_closed)
-			}
-			RemoteClosedPoll::Killed => Connection::Killed,
+			RemoteClosedPoll::RemoteClosed(remote_closed) => Self::RemoteClosed(remote_closed),
+			RemoteClosedPoll::Killed => Self::Killed,
 		}
 	}
 }
 impl From<LocalClosed> for Connection {
 	#[inline(always)]
 	fn from(local_closed: LocalClosed) -> Self {
-		Connection::LocalClosed(local_closed)
+		Self::LocalClosed(local_closed)
 	}
 }
 impl From<LocalClosedPoll> for Connection {
 	#[inline(always)]
 	fn from(local_closed_poll: LocalClosedPoll) -> Self {
 		match local_closed_poll {
-			LocalClosedPoll::LocalClosed(local_closed) => Connection::LocalClosed(local_closed),
-			LocalClosedPoll::Closing(closing) => Connection::Closing(closing),
-			LocalClosedPoll::Closed => Connection::Closed,
-			LocalClosedPoll::Killed => Connection::Killed,
+			LocalClosedPoll::LocalClosed(local_closed) => Self::LocalClosed(local_closed),
+			LocalClosedPoll::Closing(closing) => Self::Closing(closing),
+			LocalClosedPoll::Closed => Self::Closed,
+			LocalClosedPoll::Killed => Self::Killed,
 		}
 	}
 }
 impl From<Closing> for Connection {
 	#[inline(always)]
 	fn from(closing: Closing) -> Self {
-		Connection::Closing(closing)
+		Self::Closing(closing)
 	}
 }
 impl From<ClosingPoll> for Connection {
 	#[inline(always)]
 	fn from(closing_poll: ClosingPoll) -> Self {
 		match closing_poll {
-			ClosingPoll::Closing(closing) => Connection::Closing(closing),
-			ClosingPoll::Closed => Connection::Closed,
-			ClosingPoll::Killed => Connection::Killed,
+			ClosingPoll::Closing(closing) => Self::Closing(closing),
+			ClosingPoll::Closed => Self::Closed,
+			ClosingPoll::Killed => Self::Killed,
 		}
 	}
 }

--- a/src/connection_states.rs
+++ b/src/connection_states.rs
@@ -5,7 +5,6 @@ use log::trace;
 use nix::{errno, fcntl, libc, sys::socket, unistd};
 use std::{mem, net, time};
 
-#[derive(Debug)]
 pub struct Listener {
 	fd: Fd,
 	is_socket_forwarder: bool,
@@ -181,6 +180,15 @@ impl Drop for Listener {
 		panic!("Don't drop Listener");
 	}
 }
+impl fmt::Debug for Listener {
+	fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+		fmt.debug_struct("Listener")
+			.field("fd", &self.fd)
+			.field("socket", &socketstat::socketstat(self.fd))
+			.field("is_socket_forwarder", &self.is_socket_forwarder)
+			.finish()
+	}
+}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -191,7 +199,6 @@ pub enum ConnecterPoll {
 	RemoteClosed(RemoteClosed),
 	Killed,
 }
-#[derive(Debug)]
 pub struct Connecter {
 	state: Option<Fd>,
 	local: net::SocketAddr,
@@ -323,6 +330,16 @@ impl Drop for Connecter {
 		panic!("Don't drop Connecter");
 	}
 }
+impl fmt::Debug for Connecter {
+	fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+		fmt.debug_struct("Connecter")
+			.field("state", &self.state)
+			.field("socket", &self.state.map(socketstat::socketstat))
+			.field("local", &self.local)
+			.field("remote", &self.remote)
+			.finish()
+	}
+}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -333,7 +350,6 @@ pub enum ConnecteePoll {
 	RemoteClosed(RemoteClosed),
 	Killed,
 }
-#[derive(Debug)]
 pub struct Connectee {
 	fd: Fd,
 	remote: net::SocketAddr,
@@ -382,6 +398,15 @@ impl Drop for Connectee {
 		panic!("Don't drop Connectee");
 	}
 }
+impl fmt::Debug for Connectee {
+	fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+		fmt.debug_struct("Connectee")
+			.field("fd", &self.fd)
+			.field("socket", &socketstat::socketstat(self.fd))
+			.field("remote", &self.remote)
+			.finish()
+	}
+}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -393,7 +418,6 @@ pub enum ConnecterLocalClosedPoll {
 	Closed,
 	Killed,
 }
-#[derive(Debug)]
 pub struct ConnecterLocalClosed {
 	state: Option<Fd>,
 	local: net::SocketAddr,
@@ -477,6 +501,16 @@ impl Drop for ConnecterLocalClosed {
 		panic!("Don't drop ConnecterLocalClosed");
 	}
 }
+impl fmt::Debug for ConnecterLocalClosed {
+	fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+		fmt.debug_struct("ConnecterLocalClosed")
+			.field("state", &self.state)
+			.field("socket", &self.state.map(socketstat::socketstat))
+			.field("local", &self.local)
+			.field("remote", &self.remote)
+			.finish()
+	}
+}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -488,7 +522,6 @@ pub enum ConnecteeLocalClosedPoll {
 	Closed,
 	Killed,
 }
-#[derive(Debug)]
 pub struct ConnecteeLocalClosed {
 	fd: Fd,
 	remote: net::SocketAddr,
@@ -543,6 +576,15 @@ impl Drop for ConnecteeLocalClosed {
 		panic!("Don't drop ConnecteeLocalClosed");
 	}
 }
+impl fmt::Debug for ConnecteeLocalClosed {
+	fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+		fmt.debug_struct("ConnecteeLocalClosed")
+			.field("fd", &self.fd)
+			.field("socket", &socketstat::socketstat(self.fd))
+			.field("remote", &self.remote)
+			.finish()
+	}
+}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -552,7 +594,6 @@ pub enum ConnectedPoll {
 	RemoteClosed(RemoteClosed),
 	Killed,
 }
-#[derive(Debug)]
 pub struct Connected {
 	fd: Fd,
 	send: Option<CircularBuffer<u8>>,
@@ -666,6 +707,18 @@ impl Drop for Connected {
 		panic!("Don't drop Connected");
 	}
 }
+impl fmt::Debug for Connected {
+	fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+		fmt.debug_struct("Connected")
+			.field("fd", &self.fd)
+			.field("socket", &socketstat::socketstat(self.fd))
+			.field("send", &self.send)
+			.field("recv", &self.recv)
+			.field("remote_closed", &self.remote_closed)
+			.field("remote", &self.remote)
+			.finish()
+	}
+}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -674,7 +727,6 @@ pub enum RemoteClosedPoll {
 	RemoteClosed(RemoteClosed),
 	Killed,
 }
-#[derive(Debug)]
 pub struct RemoteClosed {
 	fd: Fd,
 	send: Option<CircularBuffer<u8>>,
@@ -740,6 +792,16 @@ impl Drop for RemoteClosed {
 		panic!("Don't drop RemoteClosed");
 	}
 }
+impl fmt::Debug for RemoteClosed {
+	fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+		fmt.debug_struct("RemoteClosed")
+			.field("fd", &self.fd)
+			.field("socket", &socketstat::socketstat(self.fd))
+			.field("send", &self.send)
+			.field("remote", &self.remote)
+			.finish()
+	}
+}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -750,7 +812,6 @@ pub enum LocalClosedPoll {
 	Closed,
 	Killed,
 }
-#[derive(Debug)]
 pub struct LocalClosed {
 	fd: Fd,
 	send: Option<CircularBuffer<u8>>,
@@ -868,6 +929,19 @@ impl Drop for LocalClosed {
 		panic!("Don't drop LocalClosed");
 	}
 }
+impl fmt::Debug for LocalClosed {
+	fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+		fmt.debug_struct("LocalClosed")
+			.field("fd", &self.fd)
+			.field("socket", &socketstat::socketstat(self.fd))
+			.field("send", &self.send)
+			.field("recv", &self.recv)
+			.field("remote_closed", &self.remote_closed)
+			.field("local_closed_given", &self.local_closed_given)
+			.field("remote", &self.remote)
+			.finish()
+	}
+}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -877,7 +951,6 @@ pub enum ClosingPoll {
 	Closed,
 	Killed,
 }
-#[derive(Debug)]
 pub struct Closing {
 	fd: Fd,
 	send: Option<CircularBuffer<u8>>,
@@ -946,5 +1019,117 @@ impl Closing {
 impl Drop for Closing {
 	fn drop(&mut self) {
 		panic!("Don't drop Closing");
+	}
+}
+impl fmt::Debug for Closing {
+	fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+		fmt.debug_struct("Closing")
+			.field("fd", &self.fd)
+			.field("socket", &socketstat::socketstat(self.fd))
+			.field("send", &self.send)
+			.field("local_closed_given", &self.local_closed_given)
+			.field("remote", &self.remote)
+			.finish()
+	}
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+mod sockstate {
+	use nix::libc;
+	use std::convert::TryInto;
+
+	use super::Fd;
+
+	#[derive(PartialEq, Eq, Debug)]
+	#[allow(non_camel_case_types)]
+	pub enum TcpState {
+		CLOSED,       // 0: closed
+		LISTEN,       // 1: listening for connection
+		SYN_SENT,     // 2: active, have sent syn
+		SYN_RECEIVED, // 3: have send and received syn
+		ESTABLISHED,  // 4: established
+		_CLOSE_WAIT,  // 5: rcvd fin, waiting for close
+		FIN_WAIT_1,   // 6: have closed, sent fin
+		CLOSING,      // 7: closed xchd FIN; await FIN ACK
+		LAST_ACK,     // 8: had fin and close; await FIN ACK
+		FIN_WAIT_2,   // 9: have closed, fin is acked
+		TIME_WAIT,    // 10: in 2*msl quiet wait after close
+		RESERVED,     // 11: pseudo state: reserved
+	}
+	impl TcpState {
+		fn from_raw(state: u8) -> Self {
+			match state {
+				0 => TcpState::CLOSED,
+				1 => TcpState::LISTEN,
+				2 => TcpState::SYN_SENT,
+				3 => TcpState::SYN_RECEIVED,
+				4 => TcpState::ESTABLISHED,
+				5 => TcpState::_CLOSE_WAIT,
+				6 => TcpState::FIN_WAIT_1,
+				7 => TcpState::CLOSING,
+				8 => TcpState::LAST_ACK,
+				9 => TcpState::FIN_WAIT_2,
+				10 => TcpState::TIME_WAIT,
+				11 => TcpState::RESERVED,
+				_ => unreachable!(),
+			}
+		}
+	}
+
+	pub fn sockstate(fd: Fd) -> TcpState {
+		let mut info: tcp_connection_info = tcp_connection_info::default();
+		let mut len: libc::socklen_t = std::mem::size_of::<tcp_connection_info>()
+			.try_into()
+			.unwrap();
+		let res = unsafe {
+			libc::getsockopt(
+				fd,
+				libc::IPPROTO_TCP,
+				TCP_CONNECTION_INFO,
+				{
+					let info: *mut _ = &mut info;
+					info
+				} as *mut _,
+				&mut len,
+			)
+		};
+		let res = nix::errno::Errno::result(res).unwrap();
+		assert_eq!(res, 0);
+		TcpState::from_raw(info.tcpi_state)
+	}
+
+	// https://github.com/apple/darwin-xnu/blob/a449c6a3b8014d9406c2ddbdc81795da24aa7443/bsd/netinet/tcp.h
+
+	const TCP_CONNECTION_INFO: libc::c_int = 0x106; /* State of TCP connection */
+
+	#[derive(Copy, Clone, Default)]
+	#[repr(C)]
+	struct tcp_connection_info {
+		tcpi_state: u8,      /* connection state */
+		tcpi_snd_wscale: u8, /* Window scale for send window */
+		tcpi_rcv_wscale: u8, /* Window scale for receive window */
+		__pad1: u8,
+		tcpi_options: u32,      /* TCP options supported */
+		tcpi_flags: u32,        /* flags */
+		tcpi_rto: u32,          /* retransmit timeout in ms */
+		tcpi_maxseg: u32,       /* maximum segment size supported */
+		tcpi_snd_ssthresh: u32, /* slow start threshold in bytes */
+		tcpi_snd_cwnd: u32,     /* send congestion window in bytes */
+		tcpi_snd_wnd: u32,      /* send widnow in bytes */
+		tcpi_snd_sbbytes: u32,  /* bytes in send socket buffer, including in-flight data */
+		tcpi_rcv_wnd: u32,      /* receive window in bytes*/
+		tcpi_rttcur: u32,       /* most recent RTT in ms */
+		tcpi_srtt: u32,         /* average RTT in ms */
+		tcpi_rttvar: u32,       /* RTT variance */
+		tcpi_tfo: u32,
+		tcpi_txpackets: u64,
+		tcpi_txbytes: u64,
+		tcpi_txretransmitbytes: u64,
+		tcpi_rxpackets: u64,
+		tcpi_rxbytes: u64,
+		tcpi_rxoutoforderbytes: u64,
+		tcpi_txretransmitpackets: u64,
 	}
 }

--- a/src/connection_states.rs
+++ b/src/connection_states.rs
@@ -1065,18 +1065,18 @@ mod sockstate {
 	impl TcpState {
 		fn from_raw(state: u8) -> Self {
 			match state {
-				0 => TcpState::CLOSED,
-				1 => TcpState::LISTEN,
-				2 => TcpState::SYN_SENT,
-				3 => TcpState::SYN_RECEIVED,
-				4 => TcpState::ESTABLISHED,
-				5 => TcpState::_CLOSE_WAIT,
-				6 => TcpState::FIN_WAIT_1,
-				7 => TcpState::CLOSING,
-				8 => TcpState::LAST_ACK,
-				9 => TcpState::FIN_WAIT_2,
-				10 => TcpState::TIME_WAIT,
-				11 => TcpState::RESERVED,
+				0 => Self::CLOSED,
+				1 => Self::LISTEN,
+				2 => Self::SYN_SENT,
+				3 => Self::SYN_RECEIVED,
+				4 => Self::ESTABLISHED,
+				5 => Self::_CLOSE_WAIT,
+				6 => Self::FIN_WAIT_1,
+				7 => Self::CLOSING,
+				8 => Self::LAST_ACK,
+				9 => Self::FIN_WAIT_2,
+				10 => Self::TIME_WAIT,
+				11 => Self::RESERVED,
 				_ => unreachable!(),
 			}
 		}

--- a/src/connection_states.rs
+++ b/src/connection_states.rs
@@ -626,6 +626,8 @@ impl Connected {
 				Ok((_read, false)) => (),
 				Ok((_read, true)) => {
 					trace!("Connected got closed {}", format_remote(self.remote));
+					#[cfg(any(target_os = "macos", target_os = "ios"))]
+					assert_ne!(sockstate::sockstate(self.fd), sockstate::TcpState::ESTABLISHED, "this is a bug in macOS; see tcp_typed/src/socket_forwarder.rs for a mitigation");
 					self.remote_closed = true;
 				}
 				Err(err) => {
@@ -863,6 +865,8 @@ impl LocalClosed {
 				Ok((_read, false)) => (),
 				Ok((_read, true)) => {
 					trace!("LocalClosed got closed {}", format_remote(self.remote));
+					#[cfg(any(target_os = "macos", target_os = "ios"))]
+					assert_ne!(sockstate::sockstate(self.fd), sockstate::TcpState::ESTABLISHED, "this is a bug in macOS; see tcp_typed/src/socket_forwarder.rs for a mitigation");
 					self.remote_closed = true;
 				}
 				Err(err) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! Currently doesn't support Windows.
 
-#![doc(html_root_url = "https://docs.rs/tcp_typed/0.1.2")]
+#![doc(html_root_url = "https://docs.rs/tcp_typed/0.1.4")]
 #![warn(
 	// missing_copy_implementations,
 	// missing_debug_implementations,


### PR DESCRIPTION
It turns out that calling `close(fd)` right after sending `fd` to another process can corrupt its state on macOS. A sleep is introduced to mitigate this 👀 plus it should now panic rather than hang.

Also improved debug printing of connections.